### PR TITLE
fix: Add key prop to unordered list items to suppress warning

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -25,6 +25,8 @@
   background-color: #fff;
   z-index: 1;
   width: 150px;
+  height: 150px;
+  overflow-y: scroll;
   top: 100%;
 }
 
@@ -46,6 +48,8 @@
 
 .dropdown_bd.dropdown_bd-2 {
   left: 150px;
+  height: 150px;
+  overflow-y: scroll;
 }
 
 .u-category-arrow {

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class CategorySelect extends React.Component {
   toggleShow(forceHide = false) {
     let { show } = this.state;
     show = forceHide ? false : !show;
-    this.setState({ show, childCateList: null }); 
+    this.setState({ show, childCateList: null });
   }
 
   collapse(category, e) {
@@ -66,12 +66,21 @@ class CategorySelect extends React.Component {
     return selectedName;
   }
 
+  // Get a random integer between `min` and `max`.
+  // Reference: https://gist.github.com/kerimdzhanov/7529623
+  getRandomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
   render() {
     const { childCateList, show } = this.state;
     const { categories, idKey, nameKey, childName, defaultName } = this.props;
 
     const defaultCate = { [idKey]: '', [nameKey]: defaultName };
     const _categories = [ defaultCate ,...categories];
+
+    const smallInt = 1;
+    const largeInt = 1000;
 
     return (
       <div className="u-category-dropdown" ref={(node) => (this.wrapperRef = node)}>
@@ -86,7 +95,7 @@ class CategorySelect extends React.Component {
           {
             _categories.map(category => {
               return (
-                <li onClick={this.onChange.bind(this, category)}>
+                <li key={this.getRandomInt(smallInt, largeInt)} onClick={this.onChange.bind(this, category)}>
                   <span>{category[nameKey]}</span>
                   {category[childName] ?
                   <span
@@ -109,7 +118,7 @@ class CategorySelect extends React.Component {
           {
             (childCateList || []).map(category => {
               return (
-                <li onClick={this.onChange.bind(this, category)}>
+                <li key={this.getRandomInt(smallInt, largeInt)} onClick={this.onChange.bind(this, category)}>
                   <span>{category[nameKey]}</span>
                 </li>
               )


### PR DESCRIPTION
Suppresses warnings `Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `CategorySelect`. See https://fb.me/react-warning-keys for more information.`